### PR TITLE
[WIP] Add update via handler index for handlers

### DIFF
--- a/lib/extended_bundler/cache.rb
+++ b/lib/extended_bundler/cache.rb
@@ -1,0 +1,40 @@
+module ExtendedBundler
+  module Errors
+    class Cache
+      CACHE_URL = "https://jules2689.github.io/extended_bundler-errors/"
+      CACHE_EXPIRY = 60 * 60 * 24 # 1 day
+
+      class << self
+        def handlers_index
+          if cache_expired?
+            File.write(cache_file, Time.now.utc.iso8601)
+            fetch_file('index').lines
+          else
+            nil
+          end
+        end
+
+        def fetch_file(file)
+          require "net/http"
+          require "uri"
+          url = File.join(CACHE_URL, file)
+          uri = URI.parse(url)
+          Net::HTTP.get_response(uri).body
+        end
+
+        private
+
+        def cache_expired?
+          require 'time'
+          Time.parse(File.read(cache_file)).utc - Time.now.utc > CACHE_EXPIRY
+        rescue ArgumentError, Errno::ENOENT
+          true
+        end
+
+        def cache_file
+          File.expand_path("../../index_cache_time", __dir__)
+        end
+      end
+    end
+  end
+end

--- a/lib/extended_bundler/cache.rb
+++ b/lib/extended_bundler/cache.rb
@@ -8,7 +8,7 @@ module ExtendedBundler
         def handlers_index
           if cache_expired?
             File.write(cache_file, Time.now.utc.iso8601)
-            fetch_file('index').lines
+            fetch_file('cache/index').lines
           else
             nil
           end
@@ -32,7 +32,7 @@ module ExtendedBundler
         end
 
         def cache_file
-          File.expand_path("../../index_cache_time", __dir__)
+          File.expand_path("../../cache/index_cache_time", __dir__)
         end
       end
     end

--- a/lib/extended_bundler/errors.rb
+++ b/lib/extended_bundler/errors.rb
@@ -91,6 +91,16 @@ It is recommended to:
           puts "[ExtendedBundler] Updating #{File.basename(handler, '.yml')}"
           File.write(handler, Cache.fetch_file(handler))
         end
+      rescue => e
+        path = File.expand_path("../../cache/error_#{Time.now.to_i}", __dir__)
+        File.write(path, e.backtrace.join("\n"))
+
+        puts "[ExtendedBundler] There was an error updating the handlers. We will try again in a day."
+        puts "[ExtendedBundler] In the mean time, it would be appreciated to get an issue report."
+        puts "[ExtendedBundler] Error: #{e}"
+        puts ""
+        puts "[ExtendedBundler] Click here to open an issue: #{ExtendedBundler::Errors::HOMEPAGE}/issues/new?title=#{e}"
+        puts "[ExtendedBundler] Please include the content of #{path}"
       end
 
       def version_match?(spec_version, matching_versions)


### PR DESCRIPTION
This allows us to release new handlers that will be deployed within a day of running `bundle install`
It works by downloading the `index` from master on github pages and checking existence and mtimes
of all files we have locally. If we are missing or outdated on a file, we download from github pages

This runs at most once per day and slows down the command by about 1 second that one time. Otherwise there is almost no impact.