### PR TITLE
Add nokogiri handler for stdio issues

### DIFF
--- a/lib/extended_bundler/handlers/nokogiri.yml
+++ b/lib/extended_bundler/handlers/nokogiri.yml
@@ -20,7 +20,8 @@
 
       Mac:
         Option 1: Install Command Line Tools.
-        This may not always work and the tools may already be installed. It is a good first attempt to fix.
+        This may not always work and the tools may already be installed.
+        It is a good first attempt to fix.
         {{command:xcode-select --install}}
 
         Option 2: Install SDK headers directly.

--- a/lib/extended_bundler/handlers/nokogiri.yml
+++ b/lib/extended_bundler/handlers/nokogiri.yml
@@ -1,0 +1,30 @@
+-
+  versions: all
+  matching:
+   - "fatal error:.+?stdio.h"
+  messages:
+    en: |
+      {{bold:What is the problem?}}
+      The {{info:/usr/include}} folder is missing.
+      This folder includes the {{info:stdio.h}} header needed for compiling
+
+      {{bold:What can I do?}}
+      Linux:
+        Start by updating the APT indices:
+        {{command:sudo apt-get update}}
+
+        Then installing these packages may help:
+        {{command:sudo apt-get install gcc}}
+        {{command:sudo apt-get install build-essential}}
+        {{command:sudo apt-get install libc6-dev}}
+
+      Mac:
+        Option 1: Install Command Line Tools.
+        This may not always work and the tools may already be installed. It is a good first attempt to fix.
+        {{command:xcode-select --install}}
+
+        Option 2: Install SDK headers directly.
+        {{command:cd /Library/Developer/CommandLineTools/Packages/}}
+        {{command:open macOS_SDK_headers_for_macOS_*.pkg}}
+
+        Once this is done, you should have a {{info:/usr/include}} folder with header files.


### PR DESCRIPTION
This adds a handler for Nokogiri failing on `stdio.h` headers missing.

Linux answers came from: https://stackoverflow.com/questions/19500018/unable-to-compile-simple-c-program-in-linux-mint-15
Mac ansers came from: https://twitter.com/nateberkopec/status/1123971467048304641

